### PR TITLE
lib: Remove redundant slash in def_tmp

### DIFF
--- a/libbieoffice_lib.sh
+++ b/libbieoffice_lib.sh
@@ -14,7 +14,7 @@ zip_md5=bfa18271cf413c17db04c1b775ed3571
 # defaults
 def_art=TMPDIR/${zip_filename%_full.zip}
 def_install=/
-def_tmp=/tmp/libbieoffice_mod/
+def_tmp=/tmp/libbieoffice_mod
 tmpdir="$def_tmp"
 installdir="$def_install"
 art_dir="$tmpdir/${zip_filename%_full.zip}"


### PR DESCRIPTION
The trailing slash is not necessary, this patch removes it.

NOTE: This patch is done on GitHub web editor without any testing, please review.

Refer-to: GitHub issue #1 
Signed-off-by: 林博仁 <Buo.Ren.Lin@gmail.com>