### PR TITLE
Fix for lib64 when copying intro.png 

### DIFF
--- a/libbieoffice_mod.sh
+++ b/libbieoffice_mod.sh
@@ -120,6 +120,9 @@ for mode in color blackwhite ; do
 done
 
 cp "$tmpdir/intro.png" "$installdir/usr/lib/libreoffice/program/intro.png"
+if [ $? -ne 0 ] ; then
+    cp "$tmpdir/intro.png" "$installdir/usr/lib64/libreoffice/program/intro.png"
+fi
 
 install_icon_group color ${color_themes[@]}
 install_icon_group blackwhite ${blackwhite_themes[@]}


### PR DESCRIPTION
This patch checks the result of copying intro.png. If the copy fails, then another copy is attempted with /lib64/ in the path instead of /lib/.

This is a redo of  #5. That PR is closed because it accidentally contained unrelated work.