### PR TITLE
Change Dropbox links to archive.org links

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -43,7 +43,7 @@ provides=('libreoffice' 'libreoffice-en-US')
 conflicts=('libreoffice-still' 'libreoffice-fresh')
 
 source=("https://mirror.pkgbuild.com/extra/os/x86_64/libreoffice-fresh-${_parentVer}-${_parentRel}-x86_64.pkg.tar.xz"
-        "20170826_tysontan_libbie.zip::https://www.dropbox.com/s/77r848yux6oof8g/20170826_tysontan_libbie_full.zip?dl=0"
+        "20170826_tysontan_libbie.zip::https://ia601504.us.archive.org/view_archive.php?archive=/17/items/20170826-tysontan-libbie-full/20170826_tysontan_libbie_full.zip"
         "libbieoffice_mod.sh"
         "libbieoffice_lib.sh"
         "left_libbie.png"

--- a/libbieoffice_lib.sh
+++ b/libbieoffice_lib.sh
@@ -7,7 +7,7 @@ if ((BASH_VERSINFO[0] < 4)); then
     exit 1
 fi
 
-zip_download="https://www.dropbox.com/s/77r848yux6oof8g/20170826_tysontan_libbie_full.zip?dl=1"
+zip_download="https://archive.org/download/20170826-tysontan-libbie-full/20170826_tysontan_libbie_full.zip"
 zip_filename=20170826_tysontan_libbie_full.zip
 zip_md5=bfa18271cf413c17db04c1b775ed3571
 


### PR DESCRIPTION
Dropbox is a volatile file storage service. I went ahead and changed the two links to Dropbox within your script to links to the same files at the [Internet Archive backup I created](https://archive.org/details/20170826-tysontan-libbie-full). 

Edit: tested the script in my pull request and it seems to work the same as the old one, though there's no reason it wouldn't.